### PR TITLE
chore: fix compatibility with numpy2

### DIFF
--- a/datasieve/transforms/dissimilarity_index.py
+++ b/datasieve/transforms/dissimilarity_index.py
@@ -35,7 +35,7 @@ class DissimilarityIndex(BaseTransform):
             pairwise = pairwise_distances(X)
 
         # remove the diagonal distances which are itself distances ~0
-        np.fill_diagonal(pairwise, np.NaN)
+        np.fill_diagonal(pairwise, np.nan)
         pairwise = pairwise.reshape(-1, 1)
         self.avg_mean_dist = pairwise[~np.isnan(pairwise)].mean()
         self.trained_data = X

--- a/datasieve/utils.py
+++ b/datasieve/utils.py
@@ -56,7 +56,7 @@ def find_training_horizon(df: pd.DataFrame, target_horizon, test_pct=0.05,
             current_window_distances = pairwise_distances(
                 current_window, metric="euclidean", n_jobs=8)
             # remove the diagonal distances which are itself distances ~0
-            # np.fill_diagonal(current_window_distances, np.NaN)
+            # np.fill_diagonal(current_window_distances, np.nan)
             current_window_distances = current_window_distances.reshape(-1, 1)
             std_train_dist = current_window_distances[~np.isnan(current_window_distances)].std()
             distances_horizon_current_window = pairwise_distances(


### PR DESCRIPTION
numpy2 removed the use of `np.NaN` - and replaced it with `np.nan` - which is also available in older versions.

This is hence a very small compatibility update. 

(obviously, a timely release would be apreciated, as this is now the (presumably last) blocker to update numpy to 2 in freqtrade.